### PR TITLE
Patch Migo.Net string download for UTF-8 BOM removal

### DIFF
--- a/src/Libraries/Migo/Migo.Net/AsyncWebClient.cs
+++ b/src/Libraries/Migo/Migo.Net/AsyncWebClient.cs
@@ -709,6 +709,9 @@ namespace Migo.Net
             }
         }
 
+        private readonly string _byteOrderMarkUtf8 =
+            Encoding.UTF8.GetString(Encoding.UTF8.GetPreamble());
+
         private void DownloadCompleted (byte[] resultPtr,
                                         Exception errPtr,
                                         bool cancelledCpy,
@@ -729,6 +732,11 @@ namespace Migo.Net
                     if (resultPtr != null) {
                         try {
                             s = Encoding.GetString (resultPtr).TrimStart ();
+
+                            // Workaround UTF-8 BOM
+                            if (s.StartsWith(_byteOrderMarkUtf8)) {
+                                s = s.Remove(0, _byteOrderMarkUtf8.Length);
+                            }
 
                             // Workaround if the string is a XML to set the encoding from it
                             if (s.StartsWith("<?xml")) {


### PR DESCRIPTION
- Fixes UTF-8 RSS parsing by removing the UTF-8 Byte Order Mark,
  if present, before handing off the downloaded content to the
  RSS xml parser.
- Because the Migo.Net async web client is fixed, additional users
  of this class are also fixed against any UTF-8 BOM that may be
  present.

This patch specifically fixes the bug posted to the [Multimedia Gentoo Forum](https://forums.gentoo.org/viewtopic-t-934052-view-previous.html?sid=bc361c68c6892681843c8fc2808e4a96).
